### PR TITLE
Implement intent detection UI

### DIFF
--- a/src/components/ui/containers/ChatSection.tsx
+++ b/src/components/ui/containers/ChatSection.tsx
@@ -15,6 +15,7 @@ export default function ChatSection({
   onMessageChange,
   onSend,
   onQuickOptionSelect,
+  intentNotice,
 }: ChatSectionProps) {
   const quickOptions = [
     { title: "Ayudame a buscar una casa", detail: "En Asunción para alquiler" },
@@ -46,6 +47,12 @@ export default function ChatSection({
               </div>
             </div>
           </main>
+        </div>
+      )}
+
+      {intentNotice && (
+        <div className="bg-green-100 text-green-700 text-sm p-2 text-center">
+          {intentNotice}
         </div>
       )}
 

--- a/src/services/sendIntent.ts
+++ b/src/services/sendIntent.ts
@@ -1,0 +1,14 @@
+export default async function sendIntent(intent: any) {
+  const res = await fetch('http://localhost:5000/api/intent', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(intent),
+  });
+
+  if (!res.ok) {
+    const errJson = await res.json().catch(() => ({}));
+    throw new Error(errJson.message || 'Error enviando la intención');
+  }
+
+  return res.json();
+}

--- a/src/types/generalTypes.ts
+++ b/src/types/generalTypes.ts
@@ -70,6 +70,7 @@ export interface ChatSectionProps {
   onMessageChange: (msg: string) => void;
   onSend: () => void;
   onQuickOptionSelect: (msg: string) => void;
+  intentNotice?: string | null;
 }
 
 


### PR DESCRIPTION
## Summary
- create service to send intent JSON to backend
- display notice when intent is ready
- pass intent flag to chat section
- parse bot messages for intent JSON

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886c3545c68832eb39b74157cfa7888