### PR TITLE
Integrate OpenAI chat workflow

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import OpenAI from 'openai';
+import { isIntentPayload, IntentPayload } from '@/types/intent';
+import { ChatMessage } from '@/types/generalTypes';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const systemPrompt = `Eres un asistente inmobiliario. Conversa con el usuario para obtener los datos necesarios de su búsqueda de propiedades. Cuando tengas tipo de propiedad, ciudad, trans_type, dormitorios, precio_min y precio_max responde exclusivamente con un JSON minificado del siguiente formato: {"ready":true,"intent":"buscar_propiedad","entidades":{...}}.`;
+
+export async function POST(req: NextRequest) {
+  try {
+    const { messages } = (await req.json()) as { messages: ChatMessage[] };
+
+    const openAiMessages = [
+      { role: 'system', content: systemPrompt },
+      ...(messages || []).map((m) => ({
+        role: m.sender === 'usuario' ? 'user' : 'assistant',
+        content: m.content,
+      })),
+    ];
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: openAiMessages,
+    });
+
+    const message = completion.choices[0].message.content?.trim() || '';
+    let ready = false;
+    let payload: IntentPayload | null = null;
+    try {
+      const parsed = JSON.parse(message);
+      if (parsed && parsed.intent === 'buscar_propiedad' && isIntentPayload(parsed.entidades)) {
+        ready = true;
+        payload = parsed as any;
+      }
+    } catch {}
+
+    return NextResponse.json({ message, ready, payload });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ message: 'Error procesando solicitud' }, { status: 500 });
+  }
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { useRef } from 'react';
+import ChatWindow from '@/components/ui/containers/ChatWindow';
+import ChatInput from '@/components/ui/containers/ChatInput';
+import useChat from '@/hooks/useChat';
+
+export default function ChatPage() {
+  const { messages, message, setMessage, send, intentNotice } = useChat();
+  const chatRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div className="h-screen flex flex-col relative">
+      {intentNotice && (
+        <div className="bg-green-100 text-green-700 text-sm p-2 text-center">
+          {intentNotice}
+        </div>
+      )}
+      <ChatWindow
+        messages={messages}
+        savedMessages={[]}
+        chatRef={chatRef}
+        onSaveBotMessage={() => {}}
+      />
+      <ChatInput message={message} onMessageChange={setMessage} onSend={send} />
+    </div>
+  );
+}

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,0 +1,37 @@
+'use client';
+import { useState } from 'react';
+import { ChatMessage } from '@/types/generalTypes';
+import { IntentPayload } from '@/types/intent';
+import { sendMessage } from '@/services/chat';
+import sendIntent from '@/services/sendIntent';
+
+export default function useChat() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [message, setMessage] = useState('');
+  const [pendingIntent, setPendingIntent] = useState<IntentPayload | null>(null);
+  const [intentNotice, setIntentNotice] = useState<string | null>(null);
+
+  const handleSend = async () => {
+    if (!message.trim()) return;
+    const userMsg: ChatMessage = { sender: 'usuario', type: 'text', content: `<p>${message}</p>` };
+    setMessages((prev) => [...prev, userMsg]);
+    setMessage('');
+    try {
+      const { message: botMsg, ready, payload } = await sendMessage([...messages, userMsg]);
+      setMessages((prev) => [...prev, { sender: 'bot', type: 'text', content: `<p>${botMsg}</p>` }]);
+      if (ready && payload) {
+        setPendingIntent(payload);
+        try {
+          await sendIntent(payload);
+          setIntentNotice('✅ Consulta lista y enviada al backend.');
+        } catch {
+          setIntentNotice('Error al enviar la consulta');
+        }
+      }
+    } catch {
+      setMessages((prev) => [...prev, { sender: 'bot', type: 'text', content: '<p>Error obteniendo respuesta</p>' }]);
+    }
+  };
+
+  return { messages, message, setMessage, send: handleSend, intentNotice, pendingIntent };
+}

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -1,0 +1,22 @@
+import { ChatMessage } from '@/types/generalTypes';
+import { IntentPayload } from '@/types/intent';
+
+export interface ChatAPIResponse {
+  message: string;
+  ready: boolean;
+  payload: IntentPayload | null;
+}
+
+export async function sendMessage(messages: ChatMessage[]): Promise<ChatAPIResponse> {
+  const res = await fetch('/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ messages }),
+  });
+
+  if (!res.ok) {
+    throw new Error('Error enviando mensaje');
+  }
+
+  return res.json();
+}

--- a/src/services/sendIntent.ts
+++ b/src/services/sendIntent.ts
@@ -1,5 +1,5 @@
 export default async function sendIntent(intent: any) {
-  const res = await fetch('http://localhost:5000/api/intent', {
+  const res = await fetch('http://localhost:4000/intent', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(intent),

--- a/src/types/intent.ts
+++ b/src/types/intent.ts
@@ -1,0 +1,20 @@
+export interface IntentPayload {
+  tipo_propiedad: string;
+  ciudad: string;
+  trans_type: string;
+  dormitorios: number;
+  precio_min: number;
+  precio_max: number;
+}
+
+export function isIntentPayload(obj: any): obj is IntentPayload {
+  return (
+    obj &&
+    typeof obj.tipo_propiedad === 'string' &&
+    typeof obj.ciudad === 'string' &&
+    typeof obj.trans_type === 'string' &&
+    typeof obj.dormitorios === 'number' &&
+    typeof obj.precio_min === 'number' &&
+    typeof obj.precio_max === 'number'
+  );
+}


### PR DESCRIPTION
## Summary
- implement API route `/api/chat` to talk to OpenAI and detect JSON intents
- add intent payload schema and validator
- create service to send chat messages and return intent info
- hook `useChat` to manage conversation and send intent to backend
- new simple chat page using the hook
- update intent service endpoint

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6887fc64996c832e9f8ce5b4ec6b493f