### PR TITLE
Configure chat endpoint to use environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,21 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Environment Variables
+
+The chat endpoint requires configuration using the following variables in your `.env` file:
+
+- `OPENAI_API_KEY` – API key for the OpenAI client.
+- `OPENAI_MODEL` – model identifier to use when generating completions.
+- `OPENAI_TEMPERATURE` – temperature value for completions.
+- `SQLCODER_BASE_URL` – optional base URL if using a self hosted API.
+
+Example:
+
+```env
+OPENAI_API_KEY=your-key
+OPENAI_MODEL=gpt-4.1-nano
+OPENAI_TEMPERATURE=0.2
+SQLCODER_BASE_URL=http://localhost:8000/
+```

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -3,7 +3,15 @@ import OpenAI from 'openai';
 import { isIntentPayload, IntentPayload } from '@/types/intent';
 import { ChatMessage } from '@/types/generalTypes';
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY!,
+  baseURL: process.env.SQLCODER_BASE_URL,
+});
+
+const model = process.env.OPENAI_MODEL || 'gpt-3.5-turbo';
+const temperature = process.env.OPENAI_TEMPERATURE
+  ? Number(process.env.OPENAI_TEMPERATURE)
+  : 0.2;
 
 const systemPrompt = `Eres un asistente inmobiliario. Conversa con el usuario para obtener los datos necesarios de su búsqueda de propiedades. Cuando tengas tipo de propiedad, ciudad, trans_type, dormitorios, precio_min y precio_max responde exclusivamente con un JSON minificado del siguiente formato: {"ready":true,"intent":"buscar_propiedad","entidades":{...}}.`;
 
@@ -20,8 +28,9 @@ export async function POST(req: NextRequest) {
     ];
 
     const completion = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo',
+      model,
       messages: openAiMessages,
+      temperature,
     });
 
     const message = completion.choices[0].message.content?.trim() || '';


### PR DESCRIPTION
## Summary
- configure the chat API endpoint to read model and temperature from env vars
- document environment variables in the README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68880f82e228832ea1c451b3eb98b641