### PR TITLE
Hide quick options by default

### DIFF
--- a/src/app/homePage/page.tsx
+++ b/src/app/homePage/page.tsx
@@ -29,7 +29,7 @@ export default function HomePage() {
 
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [message, setMessage] = useState("");
-  const [showCards, setShowCards] = useState(true);
+  const [showCards, setShowCards] = useState(false);
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [currentSession, setCurrentSession] = useState<ChatSession | null>(
     null
@@ -103,7 +103,7 @@ export default function HomePage() {
       const session = convertChat({ ...chat, mensajes: [] });
       setCurrentSession(session);
       setSessions((prev) => [...prev, session]);
-      setShowCards(true);
+      setShowCards(false);
     } catch (err) {
       console.error("Error creando chat:", err);
     }


### PR DESCRIPTION
## Summary
- hide quick welcome cards in home page by default
- keep them hidden when creating a new chat

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888130fe7c4832e914e4f657d314cc7